### PR TITLE
FI-920 add extensions to deferred patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:ci": "npm run coverage -- --ci --maxWorkers=2  --reporters=default --reporters=jest-junit",
     "coverage": "npm test -- --coverage",
     "coverage:upload": "codecov",
-    "deploy-dibs": "npm run clean && npm ci && lerna publish --exact --dist-tag dibs"
+    "deploy-dibs": "npm run clean && npm ci && lerna publish --exact --preid dibs --dist-tag dibs",
+    "deploy-dibs-alpha": "npm run clean && npm ci && lerna publish --exact --preid dibs-alpha --dist-tag dibs-alpha"
   },
   "lint-staged": {
     "*.ts": [

--- a/packages/apollo-server-core/src/execute.ts
+++ b/packages/apollo-server-core/src/execute.ts
@@ -247,6 +247,7 @@ export interface ExecutionPatchResult {
   data?: FieldValue;
   errors?: ReadonlyArray<GraphQLError>;
   path: ReadonlyArray<string | number>;
+  extensions?: Record<string, any>;
 }
 
 /**

--- a/packages/apollo-server-core/src/requestPipeline.ts
+++ b/packages/apollo-server-core/src/requestPipeline.ts
@@ -286,6 +286,7 @@ export async function processGraphQLRequest<TContext>(
           initialResponse: response,
           deferredPatches: patches!,
           requestDidEnd,
+          willSendResponse: extensionStack.willSendResponse.bind(extensionStack),
         };
       } else {
         executionDidEnd();

--- a/packages/apollo-server-core/src/requestPipelineAPI.ts
+++ b/packages/apollo-server-core/src/requestPipelineAPI.ts
@@ -13,10 +13,13 @@ import {
 } from 'graphql';
 import { KeyValueCache } from 'apollo-server-caching';
 
+
 // TODO: Get FieldValue and ExecutionPatchResult from execute
 // Copying these types over from ./execute for now, because this compiles as a separate TypeScript
 // project it can't import these types from a relative file path or through /dist? There is
 // probably some config magic that needs to be done here to get this to work...
+
+/********************************* COPY START **********************************/
 
 // Valid types a GraphQL field can take
 type FieldValue =
@@ -31,7 +34,10 @@ export interface ExecutionPatchResult {
   data?: FieldValue;
   errors?: ReadonlyArray<GraphQLError>;
   path: ReadonlyArray<string | number>;
+  extensions?: Record<string, any>;
 }
+
+/********************************** COPY END ***********************************/
 
 export interface GraphQLServiceContext {
   schema: GraphQLSchema;
@@ -63,6 +69,7 @@ export interface DeferredGraphQLResponse {
   initialResponse: GraphQLResponse;
   deferredPatches: AsyncIterable<ExecutionPatchResult>;
   requestDidEnd: () => void;
+  willSendResponse: (o: { graphqlResponse: GraphQLResponse; context: any; }) => { graphqlResponse: GraphQLResponse; context: any; };
 }
 
 export interface GraphQLRequestContext<TContext = Record<string, any>> {


### PR DESCRIPTION
I call `willSendResponse` in `requestPipeline.ts` AND call it for each value in `graphqlResponseToAsyncIterable` so now `extensions` property is added to each patch as it comes in.

~I _might_ try to rebase this off the latest minor in `apollo-server` so we can stay up-to-date depending on how much they've changed the repository. 😅~ (I'm saving this task for another day...) 

**Latest Prerelease**
`apollo-server-express@2.3.3-dibs-alpha.3`